### PR TITLE
[Feat] v25 다이렉트콜 WebSocket/RAG 연동 및 검색 분기 처리

### DIFF
--- a/src/api/frequentInquiriesApi.ts
+++ b/src/api/frequentInquiriesApi.ts
@@ -1,0 +1,133 @@
+/**
+ * ⭐ 자주 찾는 문의 API
+ *
+ * Feature Flag (mockConfig.ts의 USE_MOCK_DATA)에 따라:
+ * - true: Mock 데이터 사용
+ * - false: 실제 FastAPI 백엔드 호출
+ */
+
+import { USE_MOCK_DATA } from '@/config/mockConfig';
+import { frequentInquiriesData } from '@/data/mock';
+import { frequentInquiriesDetailData } from '@/data/frequentInquiriesDetail';
+
+// API 기본 URL
+const API_BASE_URL = 'http://127.0.0.1:8000/api/v1';
+
+export interface FrequentInquiry {
+  id: number;
+  keyword: string;
+  question: string;
+  count: number;
+  trend: 'up' | 'down' | 'same';
+  content?: string;
+  relatedDocument?: {
+    document_id: string;
+    title: string;
+    regulation?: string;
+    summary?: string;
+  };
+}
+
+interface FrequentInquiryListResponse {
+  success: boolean;
+  data: FrequentInquiry[];
+  total: number;
+  message: string;
+}
+
+/**
+ * 자주 찾는 문의 목록 조회
+ *
+ * @param limit - 조회 개수 (기본 5)
+ * @param offset - 오프셋 (페이지네이션용)
+ * @returns 자주 찾는 문의 목록
+ */
+export async function fetchFrequentInquiries(
+  limit: number = 5,
+  offset: number = 0
+): Promise<FrequentInquiry[]> {
+  if (USE_MOCK_DATA) {
+    // ⭐ Mock 모드: Mock 데이터 반환
+    console.log('[Mock] Fetching frequent inquiries:', { limit, offset });
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(frequentInquiriesData.slice(offset, offset + limit));
+      }, 300);
+    });
+  } else {
+    // ⭐ Real 모드: FastAPI 백엔드 호출
+    try {
+      console.log('[API] Fetching frequent inquiries from backend...');
+      const response = await fetch(
+        `${API_BASE_URL}/frequent-inquiries?limit=${limit}&offset=${offset}`,
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+
+      if (!response.ok) {
+        console.error('[API Error] Failed to fetch frequent inquiries:', response.status);
+        // 실패 시 Mock 데이터로 폴백
+        return frequentInquiriesData.slice(offset, offset + limit);
+      }
+
+      const result: FrequentInquiryListResponse = await response.json();
+      console.log('[API] Frequent inquiries fetched:', result.data.length, '건');
+      return result.data;
+    } catch (error) {
+      console.error('[API Error] fetchFrequentInquiries:', error);
+      // 에러 시 Mock 데이터로 폴백
+      return frequentInquiriesData.slice(offset, offset + limit);
+    }
+  }
+}
+
+/**
+ * 특정 자주 찾는 문의 상세 조회
+ *
+ * @param inquiryId - 문의 ID
+ * @returns 문의 상세 정보
+ */
+export async function fetchFrequentInquiryById(
+  inquiryId: number
+): Promise<FrequentInquiry | null> {
+  if (USE_MOCK_DATA) {
+    // ⭐ Mock 모드
+    console.log('[Mock] Fetching frequent inquiry by ID:', inquiryId);
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        const inquiry = frequentInquiriesDetailData.find((i) => i.id === inquiryId) || null;
+        resolve(inquiry);
+      }, 200);
+    });
+  } else {
+    // ⭐ Real 모드
+    try {
+      console.log('[API] Fetching frequent inquiry:', inquiryId);
+      const response = await fetch(
+        `${API_BASE_URL}/frequent-inquiries/${inquiryId}`,
+        {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+
+      if (!response.ok) {
+        console.error('[API Error] Failed to fetch frequent inquiry:', response.status);
+        // 폴백: Mock detail 데이터에서 찾기
+        return frequentInquiriesDetailData.find((i) => i.id === inquiryId) || null;
+      }
+
+      const result = await response.json();
+      return result.data;
+    } catch (error) {
+      console.error('[API Error] fetchFrequentInquiryById:', error);
+      return frequentInquiriesDetailData.find((i) => i.id === inquiryId) || null;
+    }
+  }
+}

--- a/src/app/pages/DashboardPage.tsx
+++ b/src/app/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
-import { noticesData, consultationsData, frequentInquiriesData, employeesData, simulationsData, dashboardStatsData, weeklyGoalData, teamStatsData, frequentInquiriesDetailData } from '@/data/mock';
+import { noticesData, consultationsData, employeesData, simulationsData, dashboardStatsData, weeklyGoalData, teamStatsData, frequentInquiriesDetailData } from '@/data/mock';
+import { fetchFrequentInquiries, type FrequentInquiry } from '@/api/frequentInquiriesApi';
 import { enrichConsultationData } from '../../data/consultationsDataHelper';
 import ConsultationDetailModal from '../components/modals/ConsultationDetailModal';
 import AnnouncementModal from '../components/modals/AnnouncementModal';
@@ -13,7 +14,6 @@ import { fetchConsultations, type ConsultationItem } from '@/api/consultationApi
 
 // ⭐ Mock 데이터에서 가져오기
 const stats = dashboardStatsData;
-const frequentInquiries = frequentInquiriesData;
 
 // ⭐ 우수 상담사는 이제 컴포넌트 내부에서 API로 가져옴 (아래 useEffect 참조)
 
@@ -34,6 +34,8 @@ export default function DashboardPage() {
   const [isFrequentInquiryModalOpen, setIsFrequentInquiryModalOpen] = useState(false);
   const [consultationHistory, setConsultationHistory] = useState<any[]>([]);
   const [isLoadingConsultations, setIsLoadingConsultations] = useState(true);
+  const [frequentInquiries, setFrequentInquiries] = useState<FrequentInquiry[]>([]);
+  const [isLoadingFrequentInquiries, setIsLoadingFrequentInquiries] = useState(true);
 
   // 현재 사용자 권한 확인 (localStorage에서)
   const userRole = localStorage.getItem('userRole') || 'employee';
@@ -134,6 +136,23 @@ export default function DashboardPage() {
       }
     };
     loadConsultations();
+  }, []);
+
+  // ⭐ 자주 찾는 문의 로드 (API 또는 Mock - USE_MOCK_DATA에 따라 자동 전환)
+  useEffect(() => {
+    const loadFrequentInquiries = async () => {
+      try {
+        setIsLoadingFrequentInquiries(true);
+        const inquiries = await fetchFrequentInquiries(5);
+        setFrequentInquiries(inquiries);
+      } catch (e) {
+        console.error('Failed to load frequent inquiries', e);
+        setFrequentInquiries([]);
+      } finally {
+        setIsLoadingFrequentInquiries(false);
+      }
+    };
+    loadFrequentInquiries();
   }, []);
 
   const handleConsultationClick = (consultation: any) => {

--- a/src/app/pages/SimulationPage.tsx
+++ b/src/app/pages/SimulationPage.tsx
@@ -40,14 +40,19 @@ export default function SimulationPage() {
     sessionStorage.setItem('simulationMode', 'true');
     sessionStorage.setItem('educationType', 'basic');
     sessionStorage.setItem('scenarioId', scenarioId);
+    // ⭐ [v25] 교육 카테고리 저장 (시뮬레이션 시작 API 호출용)
+    const scenario = scenarios.find(s => s.id === scenarioId);
+    if (scenario) {
+      sessionStorage.setItem('educationCategory', scenario.category);
+    }
     localStorage.removeItem('isGuideModeActive');
-    
-    navigate('/consultation/live', { 
-      state: { 
+
+    navigate('/consultation/live', {
+      state: {
         mode: 'simulation',
         educationType: 'basic',
-        scenarioId 
-      } 
+        scenarioId
+      }
     });
   };
 
@@ -224,6 +229,7 @@ export default function SimulationPage() {
                               sessionStorage.setItem('simulationMode', 'true');
                               sessionStorage.setItem('educationType', 'advanced');
                               sessionStorage.setItem('scenarioId', consultation.id);
+                              sessionStorage.setItem('educationCategory', consultation.category); // ⭐ [v25]
                               localStorage.removeItem('isGuideModeActive');
                               localStorage.setItem('simulationCase', JSON.stringify(consultation));
                               navigate('/consultation/live', {

--- a/src/utils/searchLayerHelpers.ts
+++ b/src/utils/searchLayerHelpers.ts
@@ -6,6 +6,7 @@ import { addTimestampToCard } from './timeFormatter';
 export interface SearchHandlerOptions {
   query: string;
   isCallActive: boolean;
+  isDirectIncoming: boolean;
   setSearchHistory: (history: any[]) => void;
   setSearchResults: React.Dispatch<React.SetStateAction<ScenarioCard[][]>>;
   setConsultationReferences: React.Dispatch<React.SetStateAction<ScenarioCard[]>>;
@@ -26,6 +27,7 @@ export async function handleSearchExecution(options: SearchHandlerOptions) {
   const {
     query,
     isCallActive,
+    isDirectIncoming,
     setSearchHistory,
     setSearchResults,
     setConsultationReferences,
@@ -35,7 +37,7 @@ export async function handleSearchExecution(options: SearchHandlerOptions) {
     setIsSearchHistoryOpen
   } = options;
 
-  const result = await simulateSearch(query);
+  const result = await simulateSearch(query, isDirectIncoming, isCallActive);
 
   if (result.cards.length > 0) {
     // 1. ⭐ 검색 이력 저장 (항상 - 대기 중/통화 중 무관)

--- a/src/utils/searchSimulator.ts
+++ b/src/utils/searchSimulator.ts
@@ -1,9 +1,13 @@
-// AI 검색 어시스턴트 시뮬레이터
-// Mock 데이터를 사용하여 검색 결과를 반환
+// AI 검색 어시스턴트
+// 대기콜: Mock 데이터 검색 / 다이렉트콜: 실제 RAG API 호출
 
 import { searchMockData, getDocumentNames } from '@/data/searchMockData';
 import { ScenarioCard } from '@/data/scenarios';
 import { addTimestampToCard, updateCardDisplayTime } from './timeFormatter';
+import { USE_MOCK_DATA } from '@/config/mockConfig';
+
+// RAG API 기본 URL
+const API_BASE_URL = 'http://127.0.0.1:8000/api/v1';
 
 /**
  * 검색 결과 타입
@@ -17,16 +21,95 @@ export interface SearchResult {
 }
 
 /**
- * 검색 쿼리를 시뮬레이션하여 결과 반환
+ * 실제 RAG API 호출 (다이렉트콜 전용)
  * @param query - 검색 쿼리
- * @returns 검색 결과 (2개 카드 + 메타데이터)
+ * @returns 검색 결과
  */
-export const simulateSearch = async (query: string): Promise<SearchResult> => {
+const searchWithRAG = async (query: string): Promise<SearchResult> => {
+  const startTime = performance.now();
+
+  try {
+    console.log('[RAG API] 검색 요청:', query);
+    const response = await fetch(`${API_BASE_URL}/rag/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ query, top_k: 4 }),
+    });
+
+    if (!response.ok) {
+      console.error('[RAG API] 응답 오류:', response.status);
+      return mockSearch(query); // fallback
+    }
+
+    const result = await response.json();
+    const elapsed = Math.round(performance.now() - startTime);
+
+    // currentSituation + nextStep 카드 합치기 (Mock과 동일하게 2개로 제한)
+    const rawCards = [
+      ...(result.currentSituation || []),
+      ...(result.nextStep || []),
+    ].slice(0, 2); // ⭐ Mock과 동일하게 검색당 2개 카드
+
+    if (rawCards.length === 0) {
+      console.log('[RAG API] 검색 결과 없음');
+      return {
+        query,
+        cards: [],
+        documentNames: [],
+        searchTime: elapsed,
+        accuracy: 0,
+      };
+    }
+
+    // ScenarioCard 형태로 변환 + timestamp + relevanceScore 추가
+    const cards: ScenarioCard[] = rawCards.map((card: any, idx: number) => {
+      const scenarioCard: ScenarioCard = {
+        id: card.id || `RAG-${Date.now()}-${idx}`,
+        title: card.title || '',
+        keywords: card.keywords || [],
+        content: card.content || '',
+        systemPath: card.systemPath || '',
+        requiredChecks: card.requiredChecks || [],
+        exceptions: card.exceptions || [],
+        time: card.time || '',
+        note: card.note || '',
+        regulation: card.regulation || '',
+        fullText: card.fullText || card.content || '',
+        documentType: card.documentType || 'general',
+      };
+      const withTimestamp = addTimestampToCard(scenarioCard);
+      return {
+        ...withTimestamp,
+        relevanceScore: 100 - (idx * 2.5),
+      };
+    });
+
+    console.log(`[RAG API] 검색 완료: ${cards.length}건 (${elapsed}ms)`);
+
+    return {
+      query,
+      cards,
+      documentNames: getDocumentNames(cards),
+      searchTime: elapsed,
+      accuracy: 95,
+    };
+  } catch (error) {
+    console.error('[RAG API] 검색 실패, Mock fallback:', error);
+    return mockSearch(query); // fallback
+  }
+};
+
+/**
+ * Mock 검색 (대기콜 / fallback용)
+ * @param query - 검색 쿼리
+ * @returns 검색 결과
+ */
+const mockSearch = async (query: string): Promise<SearchResult> => {
   // 0.3초 딜레이 시뮬레이션
   await new Promise(resolve => setTimeout(resolve, 300));
-  
+
   const trimmedQuery = query.trim();
-  
+
   // 1. 정확한 매칭
   if (searchMockData[trimmedQuery]) {
     const cards = searchMockData[trimmedQuery].map((card, idx) => {
@@ -45,7 +128,7 @@ export const simulateSearch = async (query: string): Promise<SearchResult> => {
       accuracy: 100 // 정확도 100%
     };
   }
-  
+
   // 2. 부분 매칭 (키워드 포함)
   for (const [key, cards] of Object.entries(searchMockData)) {
     if (key.includes(trimmedQuery) || trimmedQuery.includes(key)) {
@@ -66,17 +149,17 @@ export const simulateSearch = async (query: string): Promise<SearchResult> => {
       };
     }
   }
-  
+
   // 3. 키워드 기반 검색 (카드의 keywords 필드 검색)
   const lowerQuery = trimmedQuery.toLowerCase();
   for (const [key, cards] of Object.entries(searchMockData)) {
-    const hasMatchingKeyword = cards.some(card => 
-      card.keywords.some(keyword => 
-        keyword.toLowerCase().includes(lowerQuery) || 
+    const hasMatchingKeyword = cards.some(card =>
+      card.keywords.some(keyword =>
+        keyword.toLowerCase().includes(lowerQuery) ||
         lowerQuery.includes(keyword.toLowerCase().replace('#', ''))
       )
     );
-    
+
     if (hasMatchingKeyword) {
       const cardsWithTimestamp = cards.map((card, idx) => {
         const cardWithTimestamp = addTimestampToCard(card);
@@ -95,7 +178,7 @@ export const simulateSearch = async (query: string): Promise<SearchResult> => {
       };
     }
   }
-  
+
   // 4. 결과 없음
   return {
     query: trimmedQuery,
@@ -107,6 +190,33 @@ export const simulateSearch = async (query: string): Promise<SearchResult> => {
 };
 
 /**
+ * 검색 쿼리 실행
+ * - 기본: 실제 RAG API 호출 (대기중, 다이렉트콜 등)
+ * - 예외: 대기콜 통화 중 (isCallActive && !isDirectIncoming) → Mock 검색
+ * - Mock 모드: 항상 Mock 검색
+ *
+ * @param query - 검색 쿼리
+ * @param isDirectIncoming - 다이렉트콜 여부
+ * @param isCallActive - 통화 중 여부
+ * @returns 검색 결과 (카드 + 메타데이터)
+ */
+export const simulateSearch = async (
+  query: string,
+  isDirectIncoming: boolean = false,
+  isCallActive: boolean = false
+): Promise<SearchResult> => {
+  // 대기콜 통화 중 = 유일한 Mock 예외
+  const isWaitingCallActive = isCallActive && !isDirectIncoming;
+
+  if (USE_MOCK_DATA || isWaitingCallActive) {
+    return mockSearch(query);
+  } else {
+    // 대기중 / 다이렉트콜 / Real 모드: 실제 RAG API 호출
+    return searchWithRAG(query);
+  }
+};
+
+/**
  * 검색 가능한 쿼리 추천
  * @param partialQuery - 부분 쿼리
  * @param limit - 최대 추천 개수 (기본 5개)
@@ -114,12 +224,12 @@ export const simulateSearch = async (query: string): Promise<SearchResult> => {
  */
 export const getSuggestedQueries = (partialQuery: string, limit: number = 5): string[] => {
   if (!partialQuery.trim()) return [];
-  
+
   const lowerQuery = partialQuery.toLowerCase();
   const suggestions = Object.keys(searchMockData).filter(key =>
     key.toLowerCase().includes(lowerQuery)
   );
-  
+
   return suggestions.slice(0, limit);
 };
 
@@ -149,19 +259,19 @@ export const saveSearchHistory = (searchResult: SearchResult): SearchHistoryItem
     documentNames: searchResult.documentNames,
     accuracy: searchResult.accuracy
   };
-  
+
   // 기존 이력 가져오기
   const existingHistory = getSearchHistory();
-  
+
   // 새 이력 추가 (최신이 맨 앞)
   const updatedHistory = [historyItem, ...existingHistory];
-  
+
   // 최대 20개까지만 저장
   const limitedHistory = updatedHistory.slice(0, 20);
-  
+
   // localStorage에 저장
   localStorage.setItem('searchHistory', JSON.stringify(limitedHistory));
-  
+
   return historyItem;
 };
 
@@ -173,9 +283,9 @@ export const getSearchHistory = (): SearchHistoryItem[] => {
   try {
     const saved = localStorage.getItem('searchHistory');
     if (!saved) return [];
-    
+
     const history = JSON.parse(saved) as SearchHistoryItem[];
-    
+
     // displayTime 업데이트 (상대 시간 갱신)
     return history.map(item => ({
       ...item,


### PR DESCRIPTION
## 변경 사항

### useVoiceRecoders.ts
- wsEndpoint 옵션 추가: 교육(ws/edu) / 실전(ws/call) 엔드포인트 설정 가능
- sendMessage 함수 추가: JSON 메시지 전송 (init_simulation, text_message 등)
- customer_response 타입 처리: 교육 모드 AI 고객 TTS 응답
- connected 메시지 처리: ws/edu JSON 세션 ID 지원

### searchSimulator.ts
- searchWithRAG 함수 추가: 실제 RAG API 호출 (/api/v1/rag/)
- 검색 분기 로직: 대기콜 통화 중 → Mock, 그 외 → RAG API
- Mock fallback 처리: API 오류 시 Mock 검색으로 대체

### searchLayerHelpers.ts
- isDirectIncoming 파라미터 추가하여 검색 분기 지원

### 페이지 변경
- RealTimeConsultationPage: 다이렉트콜 WebSocket/RAG 연동
- AfterCallWorkPage: 후처리 페이지 개선
- SimulationPage: 시뮬레이션 페이지 개선
- DashboardPage: 대시보드 개선

### 신규 파일
- frequentInquiriesApi.ts: 자주 묻는 질문 API

### What to do

```
  변경 내용 상세 설명

  Backend
  파일: tts_engine.py
  변경 내용: 공백 정리만 (기능 변경 없음 - trailing whitespace 제거)
  ────────────────────────────────────────
  파일: edu_handler.py
  변경 내용: process_agent_input을 asyncio.to_thread로 감싸서 event loop 블로킹 방지
  ────────────────────────────────────────
  파일: card_generator.py
  변경 내용: DB structured JSONB 필드 활용하여 카드 데이터 우선 사용 (title, content, systemPath 등) + 테이블별
    documentType 자동 매핑
  ────────────────────────────────────────
  파일: card_pipeline.py
  변경 내용: 4개 카드 보장 로직 - LLM 카드가 부족하면 규칙 기반 카드로 채움
  ────────────────────────────────────────
  파일: db.py
  변경 내용: 모든 쿼리에 structured 컬럼 추가 (vector_search, text_search, fetch_docs_by_ids)
  ────────────────────────────────────────
  파일: rank.py
  변경 내용: 검색 결과에 structured 필드 포함하도록 수정
  Frontend
  파일: useVoiceRecoders.ts
  변경 내용: WebSocket 엔드포인트 설정 가능 (wsEndpoint), customer_response 타입 처리, sendMessage 함수 추가,
    connected 메시지 처리
  ────────────────────────────────────────
  파일: searchSimulator.ts
  변경 내용: 실제 RAG API 호출 추가 (searchWithRAG), 대기콜은 Mock / 다이렉트콜은 RAG API 사용 분기
  ────────────────────────────────────────
  파일: searchLayerHelpers.ts
  변경 내용: isDirectIncoming 파라미터 추가하여 검색 분기 지원
```